### PR TITLE
메인화면 게시글 리스트 불러오기 구현/ 협업 전 레포 최신화

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,11 +2,13 @@ import express from "express";
 import "dotenv/config.js";
 import errorHandler from "./middlewares/errorHandler.js";
 import userRouter from "./routes/user.routes.js";
+import mainRouter from "./routes/main.routes.js";
 
 const app = express();
 app.use(express.json());
 
 app.use("/api/users", userRouter);
+app.use("/api/main", mainRouter);
 
 app.use(errorHandler);
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,11 +1,13 @@
 import express from "express";
 import "dotenv/config.js";
+import cors from "cors";
 import errorHandler from "./middlewares/errorHandler.js";
 import userRouter from "./routes/user.routes.js";
 import mainRouter from "./routes/main.routes.js";
 
 const app = express();
 app.use(express.json());
+app.use(cors());
 
 app.use("/api/users", userRouter);
 app.use("/api/main", mainRouter);

--- a/src/controllers/main.controller.js
+++ b/src/controllers/main.controller.js
@@ -1,0 +1,13 @@
+import { getPostsData } from "../services/main.service.js";
+
+// 메인 화면
+const getMain = async (req, res, next) => {
+  try {
+    const result = await getPostsData();
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default { getMain };

--- a/src/routes/main.routes.js
+++ b/src/routes/main.routes.js
@@ -1,0 +1,7 @@
+import express from "express";
+const router = express.Router();
+import mainController from "../controllers/main.controller.js";
+
+router.get("/", mainController.getMain);
+
+export default router;

--- a/src/services/main.service.js
+++ b/src/services/main.service.js
@@ -1,0 +1,19 @@
+import db from "../db/server.js";
+
+// 메인 화면 게시글 정보
+export const getPostsData = async () => {
+  let sql = `SELECT
+    p.id, p.title, p.content, p.created_at, p.updated_at, p.view, p.solved,
+    u.nickname, COUNT(DISTINCT c.id) AS comment_count, COUNT(DISTINCT l.id) AS like_count,
+    GROUP_CONCAT(DISTINCT t.name) AS tags
+    FROM posts p
+    JOIN users u ON p.user_id = u.id
+    LEFT JOIN comments c ON p.id = c.post_id
+    LEFT JOIN likes l ON p.id = l.post_id
+    LEFT JOIN post_tags pt ON p.id = pt.post_id
+    LEFT JOIN tags t ON pt.tag_id = t.id
+    GROUP BY p.id, p.title, p.content, p.created_at, p.updated_at, p.view, p.solved, u.nickname`;
+  const [posts] = await db.execute(sql);
+
+  return posts;
+};


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

  - [x] 게시글 리스트 :
    메인화면에서 보여질 게시글 리스트의 데이터를 불러옵니다.
---

# 🤔 논의가 필요한 사항 (Points to discuss)

- [x] 쿼리
   쿼리를 나눠 여러번 DB에 접근해서 데이터를 얻어오고 또 그 데이터를 가공해서 리턴해주는거보다 한번에 싹 다 얻어오는게 낫겠다 싶어서 쿼리가 엄청 길어졌습니다


---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **게시글 리스트**                  | 
|-----------------------------|
|![image](https://github.com/user-attachments/assets/3762322e-1ebc-4e57-9c82-8bb20495e1d6)  |
---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)


- [ ] 페이지네이션 : 프론트에서 아직 페이지네이션을 설정하지 않아 일단 DB에 저장된 모든 값을 불러옵니다

