### PR TITLE
게시물 CRUD

### DIFF
--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -5,7 +5,7 @@ import {
   addViewCount,
   addPostData,
   addTagsData,
-  ModifyTitleAndContent,
+  modifyTitleAndContent,
   confirmAuth,
   deleteTags,
   deletePostData,
@@ -103,7 +103,7 @@ const updatePost = async (req, res, next) => {
 
     // 제목&내용 수정
     // 이 함수는 updated_at을 수정하는 로직이 포함되어 있어 title, content값이 전달되지 않아도 실행되게 설정
-    ModifyTitleAndContent(postId, title, content);
+    modifyTitleAndContent(postId, title, content);
 
     res.status(200).json({ success: true });
   } catch (err) {

--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -8,6 +8,7 @@ import {
   ModifyTitleAndContent,
   confirmAuth,
   deleteTags,
+  deletePostData,
 } from "../services/post.service.js";
 
 import { getTokenData } from "../utils/getTokenData.js";
@@ -110,4 +111,28 @@ const updatePost = async (req, res, next) => {
   }
 };
 
-export default { getPostById, creatPost, updatePost };
+const deletePost = async (req, res, next) => {
+  const userId = req.user.id;
+  const postId = req.params.id;
+  try {
+    // 권한 확인
+    const isValidId = await confirmAuth(userId, postId);
+    if (!isValidId) {
+      const error = new Error("권한이 없습니다.");
+      error.statusCode = 401;
+      throw error;
+    }
+
+    // 태그 데이터 삭제
+    deleteTags(postId);
+
+    // 게시글 데이터 삭제
+    deletePostData(postId);
+
+    //응답
+    res.status(200).json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+};
+export default { getPostById, creatPost, updatePost, deletePost };

--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -31,7 +31,7 @@ const getPostById = async (req, res, next) => {
     if (!authHeader) return res.json({ post, comments });
 
     const user = await getTokenData(authHeader);
-    const status = await getLikeAndScrapStatus(user.email, id);
+    const status = await getLikeAndScrapStatus(user.id, id);
 
     // 토큰 있을 시 게시글, 좋아요&스크랩 여부, 댓글 전달
     res.json({ post, status, comments });

--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -3,9 +3,12 @@ import {
   getCommentDataById,
   getLikeAndScrapStatus,
   addViewCount,
+  addPostData,
+  addTagsData,
 } from "../services/post.service.js";
 
 import { getTokenData } from "../utils/getTokenData.js";
+import { validateRequireField } from "../utils/validate.js";
 
 // 게시글 조회
 const getPostById = async (req, res, next) => {
@@ -40,4 +43,27 @@ const getPostById = async (req, res, next) => {
   }
 };
 
-export default { getPostById };
+// 게시글 등록
+const creatPost = async (req, res, next) => {
+  const userId = req.user.id;
+  const { title, tags, content } = req.body;
+  try {
+    // 입력값 유효성 검사
+    validateRequireField(title, "제목");
+    validateRequireField(tags, "태그");
+    validateRequireField(content, "내용");
+
+    // DB에 게시글 정보 저장 후 리턴값으로 게시글 id 받아오기
+    const postId = await addPostData(userId, title, content);
+
+    // 게시글 태그 정보 저장
+    await addTagsData(postId, tags);
+
+    // 응답
+    res.status(201).json({ success: true });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default { getPostById, creatPost };

--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -2,6 +2,7 @@ import {
   getPostDataById,
   getCommentDataById,
   getLikeAndScrapStatus,
+  addViewCount,
 } from "../services/post.service.js";
 
 import { getTokenData } from "../utils/getTokenData.js";
@@ -11,6 +12,9 @@ const getPostById = async (req, res, next) => {
   const authHeader = req.headers.authorization;
   const { id } = req.params;
   try {
+    // API 호출 시 조회수 증가
+    addViewCount(id);
+
     // 게시글 데이터
     const post = await getPostDataById(id);
     // 예외처리 404

--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -9,21 +9,27 @@ import { getTokenData } from "../utils/getTokenData.js";
 // 게시글 조회
 const getPostById = async (req, res, next) => {
   const authHeader = req.headers.authorization;
-  // 사용자의 스크랩, 좋아요 여부
   const { id } = req.params;
   try {
+    // 게시글 데이터
     const post = await getPostDataById(id);
+    // 예외처리 404
     if (!post.length) {
       const error = new Error("게시글이 존재하지 않습니다.");
       error.statusCode = 404;
       throw error;
     }
+
+    // 댓글 데이터
     const comments = await getCommentDataById(id);
+
+    // 토큰 없을 시 게시글과 댓글만 전달
     if (!authHeader) return res.json({ post, comments });
 
     const user = await getTokenData(authHeader);
     const status = await getLikeAndScrapStatus(user.email, id);
 
+    // 토큰 있을 시 게시글, 좋아요&스크랩 여부, 댓글 전달
     res.json({ post, status, comments });
   } catch (err) {
     next(err);

--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -7,7 +7,7 @@ import {
   addTagsData,
   ModifyTitleAndContent,
   confirmAuth,
-  modifyTags,
+  deleteTags,
 } from "../services/post.service.js";
 
 import { getTokenData } from "../utils/getTokenData.js";
@@ -96,7 +96,8 @@ const updatePost = async (req, res, next) => {
       // 빈 배열 전달 시 예외처리
       validateRequireField(tags, "태그");
       // 태그 수정
-      modifyTags(postId, tags);
+      deleteTags(postId);
+      addTagsData(postId, tags);
     }
 
     // 제목&내용 수정

--- a/src/controllers/post.controller.js
+++ b/src/controllers/post.controller.js
@@ -12,7 +12,6 @@ const getPostById = async (req, res, next) => {
   // 사용자의 스크랩, 좋아요 여부
   const { id } = req.params;
   try {
-    console.log(authHeader);
     const post = await getPostDataById(id);
     if (!post.length) {
       const error = new Error("게시글이 존재하지 않습니다.");

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -75,8 +75,12 @@ const loginUser = async (req, res, next) => {
     }
 
     // JWT 토큰 생성
-    const token = await makeToken(user.email, user.nickname, user.role);
-
+    const token = await makeToken(
+      user.id,
+      user.email,
+      user.nickname,
+      user.role
+    );
     // 응답 데이터
     res.json({ success: true, token });
   } catch (err) {

--- a/src/routes/post.routes.js
+++ b/src/routes/post.routes.js
@@ -10,6 +10,7 @@ router.get("/:id", postController.getPostById);
 router.post("/", authMiddleware, postController.creatPost);
 
 // 게시글 수정
+router.put("/:id", authMiddleware, postController.updatePost);
 // 게시글 삭제
 
 export default router;

--- a/src/routes/post.routes.js
+++ b/src/routes/post.routes.js
@@ -1,10 +1,14 @@
 import express from "express";
 const router = express.Router();
 import postController from "../controllers/post.controller.js";
+import authMiddleware from "../middlewares/authMiddleware.js";
 
 // 게시글 조회
 router.get("/:id", postController.getPostById);
+
 // 게시글 등록
+router.post("/", authMiddleware, postController.creatPost);
+
 // 게시글 수정
 // 게시글 삭제
 

--- a/src/routes/post.routes.js
+++ b/src/routes/post.routes.js
@@ -11,6 +11,8 @@ router.post("/", authMiddleware, postController.creatPost);
 
 // 게시글 수정
 router.put("/:id", authMiddleware, postController.updatePost);
+
 // 게시글 삭제
+router.delete("/:id", authMiddleware, postController.deletePost);
 
 export default router;

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -100,12 +100,8 @@ export const ModifyTitleAndContent = async (id, title, content) => {
   await db.execute(sql, values);
 };
 
-// 게시글 태그 수정
-export const modifyTags = async (id, tags) => {
-  // 태그 데이터 전부 삭제
+// 게시글 태그 삭제
+export const deleteTags = async (id) => {
   const sql = `DELETE FROM post_tags WHERE post_id = ?`;
   await db.execute(sql, [id]);
-
-  // 태그 데이터 재등록
-  await addTagsData(id, tags);
 };

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -86,16 +86,17 @@ export const ModifyTitleAndContent = async (id, title, content) => {
 
   // 전달된 값에 따라 쿼리문 변경
   if (title) {
-    modifyList.push("title = ?");
+    modifyList.push("title = ?,");
     values.push(title);
   }
   if (content) {
-    modifyList.push("content = ?");
+    modifyList.push("content = ?,");
     values.push(content);
   }
   values.push(id);
 
-  const sql = `UPDATE posts SET ${modifyList.join(", ")} WHERE id = ?`;
+  const sql = `UPDATE posts SET ${modifyList.join()} 
+  updated_at = CURRENT_TIMESTAMP WHERE id = ?`;
   await db.execute(sql, values);
 };
 

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -71,6 +71,14 @@ export const addTagsData = async (id, tags) => {
   await db.execute(sql, [id, ...tags]);
 };
 
+// 게시글 권한 인증
+export const confirmAuth = async (userId, postId) => {
+  const sql = `SELECT user_id FROM posts WHERE id = ?`;
+  const [result] = await db.execute(sql, [postId]);
+
+  return userId == result[0].user_id;
+};
+
 // 게시글 제목, 내용 수정
 export const ModifyTitleAndContent = async (id, title, content) => {
   const modifyList = [];

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -70,3 +70,23 @@ export const addTagsData = async (id, tags) => {
 `;
   await db.execute(sql, [id, ...tags]);
 };
+
+// 게시글 제목, 내용 수정
+export const ModifyTitleAndContent = async (id, title, content) => {
+  const modifyList = [];
+  const values = [];
+
+  // 전달된 값에 따라 쿼리문 변경
+  if (title) {
+    modifyList.push("title = ?");
+    values.push(title);
+  }
+  if (content) {
+    modifyList.push("content = ?");
+    values.push(content);
+  }
+  values.push(id);
+
+  const sql = `UPDATE posts SET ${modifyList.join(", ")} WHERE id = ?`;
+  await db.execute(sql, values);
+};

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -80,7 +80,7 @@ export const confirmAuth = async (userId, postId) => {
 };
 
 // 게시글 제목, 내용 수정
-export const ModifyTitleAndContent = async (id, title, content) => {
+export const modifyTitleAndContent = async (id, title, content) => {
   const modifyList = [];
   const values = [];
 

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -33,12 +33,8 @@ export const getCommentDataById = async (id) => {
 };
 
 // 좋아요 스크랩 여부 조회
-export const getLikeAndScrapStatus = async (email, postId) => {
-  let sql = `SELECT id FROM users WHERE email = ?`;
-  const [result] = await db.execute(sql, [email]);
-  const userId = result[0].id;
-
-  sql = `SELECT 
+export const getLikeAndScrapStatus = async (userId, postId) => {
+  const sql = `SELECT 
   EXISTS(SELECT 1 FROM scraps WHERE user_id = ? AND post_id = ?) AS scrapped,
   EXISTS(SELECT 1 FROM likes WHERE user_id = ? AND post_id = ?) AS liked`;
 

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -58,3 +58,15 @@ export const addPostData = async (id, title, content) => {
   // 저장된 게시글의 id 리턴
   return result.insertId;
 };
+
+// 게시글 태그 정보 저장
+export const addTagsData = async (id, tags) => {
+  let placeholder = Array.from({ length: tags.length }, () => "?").join(",");
+  const sql = `
+  INSERT INTO post_tags (post_id, tag_id)
+  SELECT ?, t.id 
+  FROM tags t 
+  WHERE t.name IN (${placeholder})
+`;
+  await db.execute(sql, [id, ...tags]);
+};

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -1,4 +1,5 @@
 import db from "../db/server.js";
+import { validateRequireField } from "../utils/validate.js";
 
 // 게시글 관련 데이터 조회
 export const getPostDataById = async (id) => {
@@ -46,4 +47,14 @@ export const getLikeAndScrapStatus = async (userId, postId) => {
 export const addViewCount = async (id) => {
   const sql = `UPDATE posts SET view = view + 1 WHERE id = ?`;
   await db.execute(sql, [id]);
+};
+
+// 게시글 정보 저장
+export const addPostData = async (id, title, content) => {
+  const sql = `INSERT INTO posts (user_id, title, content) VALUES (?, ?, ?)`;
+  const values = [id, title, content];
+
+  const [result] = await db.execute(sql, values);
+  // 저장된 게시글의 id 리턴
+  return result.insertId;
 };

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -98,3 +98,13 @@ export const ModifyTitleAndContent = async (id, title, content) => {
   const sql = `UPDATE posts SET ${modifyList.join(", ")} WHERE id = ?`;
   await db.execute(sql, values);
 };
+
+// 게시글 태그 수정
+export const modifyTags = async (id, tags) => {
+  // 태그 데이터 전부 삭제
+  const sql = `DELETE FROM post_tags WHERE post_id = ?`;
+  await db.execute(sql, [id]);
+
+  // 태그 데이터 재등록
+  await addTagsData(id, tags);
+};

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -105,3 +105,9 @@ export const deleteTags = async (id) => {
   const sql = `DELETE FROM post_tags WHERE post_id = ?`;
   await db.execute(sql, [id]);
 };
+
+// 게시글 삭제
+export const deletePostData = async (id) => {
+  const sql = `DELETE FROM posts WHERE id = ?`;
+  await db.execute(sql, [id]);
+};

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -45,3 +45,9 @@ export const getLikeAndScrapStatus = async (email, postId) => {
   const [status] = await db.execute(sql, [userId, postId, userId, postId]);
   return status;
 };
+
+// 조회수 증가
+export const addViewCount = async (id) => {
+  const sql = `UPDATE posts SET view = view + 1 WHERE id = ?`;
+  await db.execute(sql, [id]);
+};

--- a/src/services/user.service.js
+++ b/src/services/user.service.js
@@ -32,7 +32,7 @@ export const insertUserData = async (email, password, nickname) => {
 
 // 유저 데이터 조회
 export const findUserByEmail = async (email) => {
-  const sql = `SELECT email, nickname ,password, role FROM users WHERE email = ?`;
+  const sql = `SELECT id, email, nickname ,password, role FROM users WHERE email = ?`;
   const [user] = await db.execute(sql, [email]);
   return user[0];
 };
@@ -44,9 +44,13 @@ export const comparePassword = async (userPassword, dbPassword) => {
 };
 
 // JWT 토큰 생성
-export const makeToken = async (email, nickname, role) => {
-  const token = jwt.sign({ email, nickname, role }, process.env.JWT_SECRET, {
-    expiresIn: "1h",
-  });
+export const makeToken = async (id, email, nickname, role) => {
+  const token = jwt.sign(
+    { id, email, nickname, role },
+    process.env.JWT_SECRET,
+    {
+      expiresIn: "1h",
+    }
+  );
   return token;
 };

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -1,5 +1,5 @@
 export const validateRequireField = (field, fieldName) => {
-  if (!field) {
+  if (!field || !field.length) {
     const error = new Error(`${fieldName}을 입력해주세요`);
     error.statusCode = 400;
     throw error;


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

- ✨ 주요 기능: 게시글 API는 전부 인증 미들웨어를 사용해 토큰 오류시 예외 처리 됩니다.
  - [x] 게시글 추가
    입력값(제목, 태그, 내용) 유효성 검사 후 게시글 데이터에 저장(posts), 태그 데이터 저장(post_tags)
  - [x] 게시글 수정:
    변경 권한(게시글 유저 아이디와 토큰에 담긴 유저 아이디가 일치하는지) 확인 후 전달된 데이터에 따라 수정 (update_at 포함)
    전달된 데이터가 없어도 예외처리 하지 않고 "변경된 내용이 없습니다" 메시지 전달
  - [x] 게시글 삭제
    변경 권한 확인 후 게시글 데이터 삭제(posts), 태그 데이터 삭제(post_tags)
  - [x] 토큰 값에 유저 id 추가
    토큰 값에 유저 id가 없을 시 불필요한 DB 접근이 늘어나 추가했습니다.
  - [x] 게시글 조회 시 조회수 증가

---

# 🤔 논의가 필요한 사항 (Points to discuss)

- [ ] 게시글 수정, 삭제 예외처리
   게시글 조회는 등록되지 않은 id에 접근시 404로 예외처리를 했는데 수정/삭제는 사용자 입장에서 등록되지 않은 id에
   접근할 수 없을거라 판단해 이 부분은 따로 예외처리 해두지는 않았습니다. (쿼리 실행 오류로 에러가 발생하긴 함)
---

